### PR TITLE
Removed popup as event is postponed

### DIFF
--- a/src/Pages/HomePage.tsx
+++ b/src/Pages/HomePage.tsx
@@ -32,11 +32,13 @@ const HomePage: React.FC<HomePageProps> = ({ isMenuOpen }) => {
       <Partners />
       <TeamSection />
       
+      {/*
       <EventModal
         isOpen={showModal}
         onClose={() => setShowModal(false)}
         registrationUrl="https://unstop.com/o/hGuVyrW?lb=RfihYaz&utm_medium=Share&utm_source=shortUrl"
       />
+      */}
     </div>
   )
 }

--- a/src/components/EventModal.tsx
+++ b/src/components/EventModal.tsx
@@ -63,7 +63,7 @@ const EventModal: React.FC<EventModalProps> = ({
 
           <div className="space-y-3 sm:space-y-4">
             <h2 className="text-xl sm:text-2xl font-bold text-white">
-              🚀 Commit2Code | June 7–8
+              🚀 Commit2Code | June 7-8
             </h2>
             <p className="text-sm sm:text-base text-gray-300 line-clamp-2">
               Kickstart your journey into open source, GSoC, and freelancing with two days of expert sessions.


### PR DESCRIPTION
Commented out the popup on the homepage since the event has been postponed. 
This prevents it from showing until the event is rescheduled.
